### PR TITLE
Replace window.confirm with custom modal for mode change

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -136,6 +136,18 @@
     </div>
   </div>
 
+  <!-- Confirmation Modal -->
+  <div class="modal hidden" id="confirmModal">
+    <div class="modal-content">
+      <h2>Abandon Case?</h2>
+      <p>You have progress in this investigation. Changing modes will reset your progress. Are you sure you want to continue?</p>
+      <div class="modal-actions">
+        <button id="confirm-yes-btn" class="modal-btn">Yes, Abandon</button>
+        <button id="confirm-no-btn" class="modal-btn secondary">No, Stay</button>
+      </div>
+    </div>
+  </div>
+
   <script type="module" src="main.ts" defer></script>
 </body>
 

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -42,6 +42,7 @@ class SnooCluesGame {
   private feedbackMessage!: HTMLElement;
   private winModal!: HTMLElement;
   private playedModal!: HTMLElement;
+  private confirmModal!: HTMLElement;
   private answerText!: HTMLElement;
   private winAttempts!: HTMLElement;
   private playedAttemptsCount!: HTMLElement;
@@ -55,6 +56,8 @@ class SnooCluesGame {
   private shareBtn!: HTMLButtonElement;
   private closeWinModalBtn!: HTMLButtonElement;
   private closePlayedModalBtn!: HTMLButtonElement;
+  private confirmYesBtn!: HTMLButtonElement;
+  private confirmNoBtn!: HTMLButtonElement;
   private closeSelectionBtn!: HTMLButtonElement;
   private selectionModal!: HTMLElement;
   private gameOverlay!: HTMLElement;
@@ -87,6 +90,7 @@ class SnooCluesGame {
     this.feedbackMessage = document.getElementById("feedbackMessage")!;
     this.winModal = document.getElementById("winModal")!;
     this.playedModal = document.getElementById("playedModal")!;
+    this.confirmModal = document.getElementById("confirmModal")!;
     this.answerText = document.getElementById("answerText")!;
     this.winAttempts = document.getElementById("win-attempts-count")!;
     this.playedAttemptsCount = document.getElementById('played-attempts-count')!;
@@ -107,6 +111,8 @@ class SnooCluesGame {
     this.gameSubtitle = document.querySelector(".game-subtitle")!;
     this.closeWinModalBtn = this.winModal.querySelector(".close-modal-btn") as HTMLButtonElement;
     this.closePlayedModalBtn = this.playedModal.querySelector(".close-modal-btn") as HTMLButtonElement;
+    this.confirmYesBtn = document.getElementById("confirm-yes-btn") as HTMLButtonElement;
+    this.confirmNoBtn = document.getElementById("confirm-no-btn") as HTMLButtonElement;
     this.closeSelectionBtn = document.getElementById("closeSelectionModal") as HTMLButtonElement;
     this.currentModeTag = document.getElementById("currentModeTag")!;
     this.playedToColdBtn = document.getElementById("playedToColdBtn") as HTMLButtonElement;
@@ -154,6 +160,15 @@ class SnooCluesGame {
     this.closeWinModalBtn.addEventListener("click", () => this.closeModal("win"));
     this.closePlayedModalBtn.addEventListener("click", () => this.closeModal("played"));
 
+    this.confirmYesBtn.addEventListener("click", () => {
+      this.closeModal("confirm");
+      this.executeBackToSelection();
+    });
+
+    this.confirmNoBtn.addEventListener("click", () => {
+      this.closeModal("confirm");
+    });
+
     this.startDailyBtn.addEventListener("click", () => this.initGame('daily'));
     this.startColdBtn.addEventListener("click", () => this.initGame('unlimited'));
     this.keepTrainingBtn.addEventListener("click", () => {
@@ -181,13 +196,15 @@ class SnooCluesGame {
       this.clue3Card.classList.contains("visible");
 
     if (hasProgress && !this.isWinner) {
-      const confirmed = confirm(
-        "You have progress in this case. Changing modes will reset your progress. Continue?"
-      );
-      if (!confirmed) return;
-      this.currentGameMode = null;
+      this.showModal("confirm");
+      return;
     }
 
+    this.executeBackToSelection();
+  }
+
+  private executeBackToSelection(): void {
+    this.currentGameMode = null;
     dispatchMascotAction('switch_mode');
     this.showSelectionHub();
   }
@@ -397,12 +414,22 @@ class SnooCluesGame {
       .join("");
   }
 
-  private showModal(t: "win" | "played"): void {
-    (t === "win" ? this.winModal : this.playedModal).classList.remove("hidden");
+  private showModal(t: "win" | "played" | "confirm"): void {
+    const modalMap = {
+      win: this.winModal,
+      played: this.playedModal,
+      confirm: this.confirmModal
+    };
+    modalMap[t].classList.remove("hidden");
   }
 
-  private closeModal(t: "win" | "played"): void {
-    (t === "win" ? this.winModal : this.playedModal).classList.add("hidden");
+  private closeModal(t: "win" | "played" | "confirm"): void {
+    const modalMap = {
+      win: this.winModal,
+      played: this.playedModal,
+      confirm: this.confirmModal
+    };
+    modalMap[t].classList.add("hidden");
   }
 
   private disableInput(): void {


### PR DESCRIPTION
The "Change Case Type" button was failing when progress had been made (clues revealed or attempts made) because it relied on `window.confirm()`, which is often blocked in the Reddit Devvit environment. I replaced it with a custom modal that matches the game's aesthetic and verified it through frontend screenshot testing.

---
*PR created automatically by Jules for task [1050794330584753626](https://jules.google.com/task/1050794330584753626) started by @asifdotpy*